### PR TITLE
Avoid error on chromatogram ids that start with description containing space characters such as "SRM SIC"

### DIFF
--- a/PSI_Interface/IdentData/SimpleMZIdentMLReader.cs
+++ b/PSI_Interface/IdentData/SimpleMZIdentMLReader.cs
@@ -64,11 +64,14 @@ namespace PSI_Interface.IdentData
         {
             private static Dictionary<string, string> ParseNativeId(string nativeId)
             {
+                // Pwiz chromatograms have id starting with "SRM SIC". Splitting on space character results tokens with no '=' character
                 var tokens = nativeId.Split(new[] { '\t', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
                 var map = new Dictionary<string, string>();
 
                 foreach (var token in tokens)
                 {
+                    if (!token.Contains('='))
+                        continue;
                     var equals = token.IndexOf('=');
                     var name = token.Substring(0, equals);
                     var value = token.Substring(equals + 1);

--- a/PSI_Interface/NativeIdConversion.cs
+++ b/PSI_Interface/NativeIdConversion.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PSI_Interface
 {
@@ -11,11 +12,14 @@ namespace PSI_Interface
     {
         private static Dictionary<string, string> ParseNativeId(string nativeId)
         {
+            // Pwiz chromatograms have id starting with "SRM SIC". Splitting on space character results tokens with no '=' character
             var tokens = nativeId.Split(new[] { '\t', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
             var map = new Dictionary<string, string>();
 
             foreach (var token in tokens)
             {
+                if (!token.Contains('='))
+                    continue;
                 var equals = token.IndexOf('=');
                 var name = token.Substring(0, equals);
                 var value = token.Substring(equals + 1);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ image: Visual Studio 2022
 configuration: Release
 platform: Any CPU
 nuget:
+  account_feed: false
   disable_publish_on_pr: true
 build_script:
 - ps: msbuild PSI_Interface.sln /t:restore /t:build /p:Configuration=Release /p:Platform="Any CPU" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
Pwiz converted SRM files start with "SRM SIC" and then continue with key value pairs. The Native Id Parsing is failing on these Ids.